### PR TITLE
Updated Turn-Turn spacing for create_left_center. Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This KiCad **pcbnew Action Plugin** generates **planar magnetic windings** (rect
 
 - Rectangular spiral with rounded corners
 - Adjustable parameters:
-  - Width & Height (outer window)
+  - Width & Height (Core leg)
   - Corner Radius
   - Track Width
-  - Track Spacing (Guard)
-  - Inner Gap (first-turn clearance)
+  - Track Spacing (Turn-Turn)
+  - Inner Spacing (Turn-Core)
   - Number of Turns
   - Start position: **Left-Top / Left-Center / Left-Bottom**
 - Pick center using the **mouse** on the canvas
@@ -62,8 +62,9 @@ winding-generator/
 2. Click the **Winding Generator** toolbar icon (red spiral) or run it from  
    **Tools → External Plugins → Winding Generator**.
 3. In the dialog:
-   - Click **Use mouse** to pick the center from the canvas (or type X/Y in mm).
-   - Set **Width, Height, Radius, Gap, Track Width, Guard (spacing), Turns**.
+   - Enter the center point of the winding **Center X, Center Y**.
+   - Set the **Radius, Turn-Core (clearance), Track Width, Turn-Turn (spacing)**.
+   - Set the **Width, Height, Turns**
    - Choose **Start position** (Left-Top / Left-Center / Left-Bottom).
    - Select the **Layer** (e.g., F.Cu).
 4. Click **OK**. The spiral is drawn as TRACKs and 90° ARCs on the chosen layer.
@@ -72,18 +73,18 @@ winding-generator/
 
 ## 🔧 Parameters (Quick Reference)
 
-| Field              | Meaning                                                                 |
-|--------------------|-------------------------------------------------------------------------|
-| **Center X/Y (mm)**| Spiral center. Use **Use mouse** to capture from the canvas.           |
-| **Width (mm)**     | Outer window width of the rounded rectangle.                            |
-| **Height (mm)**    | Outer window height of the rounded rectangle.                           |
-| **Radius (mm)**    | Corner radius.                                                          |
-| **Gap (mm)**       | Inner clearance from window to first turn.                              |
-| **Width (mm)**     | Track width (copper trace width).                                       |
-| **Guard (mm)**     | Track-to-track spacing between adjacent turns.                          |
-| **Turns**          | Number of spiral turns.                                                 |
-| **Start Position** | Left-Top / Left-Center / Left-Bottom path start.                        |
-| **Layer**          | Target copper layer (F.Cu, B.Cu, In1.Cu, …).                            |
+| Field               | Meaning                                                |
+|---------------------|--------------------------------------------------------|
+| **Center X/Y (mm)** | Spiral center. Enter X and Y position in mm.           |
+| **Width (mm)**      | Width of the core leg (Diameter for round core leg).   |
+| **Height (mm)**     | Height of the core leg (Diameter for round core leg).  |
+| **Radius (mm)**     | Corner radius.                                         |
+| **Turn-Core (mm)**  | Inner clearance from the core to the first turn.       |
+| **Width (mm)**      | Track width (copper trace width).                      |
+| **Turn-Turn (mm)**  | Track-to-track spacing between adjacent turns.         |
+| **Turns**           | Number of spiral turns.                                |
+| **Start Position**  | Left-Top / Left-Center / Left-Bottom path start.       |
+| **Layer**           | Target copper layer (F.Cu, B.Cu, In1.Cu, …).           |
 
 ---
 

--- a/winding_generator.py
+++ b/winding_generator.py
@@ -399,7 +399,13 @@ def create_left_bottom(board: "pcbnew.BOARD", layer: int, center: "pcbnew.VECTOR
     now_y = ay + (w_height // 2) + Clearance + (t_width // 2)
 
     for _ in range(n):
-        add_track(board, v2(now_x, now_y), v2(now_x + f_length, now_y), layer, t_width)
+        # add a slight offset for the first turn to prevent overlap
+        first_turn_offset = 0
+        if _ == 0:
+            first_turn_offset = t_width // 2
+
+
+        add_track(board, v2(now_x + first_turn_offset, now_y), v2(now_x + f_length, now_y), layer, t_width)
         now_x = now_x + f_length
 
         add_arc(board, v2(now_x, now_y - radius_now), radius_now, 0, 90, layer, t_width)
@@ -476,7 +482,13 @@ def create_left_top(board: "pcbnew.BOARD", layer: int, center: "pcbnew.VECTOR2I"
     now_y = ay - (f_height // 2)
 
     for _ in range(n):
-        add_track(board, v2(now_x, now_y), v2(now_x, now_y + f_height), layer, t_width)
+        # add a slight offset for the first turn to prevent overlap
+        first_turn_offset = 0
+        if _ == 0:
+            first_turn_offset = t_width // 2
+
+
+        add_track(board, v2(now_x, now_y + first_turn_offset), v2(now_x, now_y + f_height), layer, t_width)
         now_y = now_y + f_height
 
         add_arc(board, v2(now_x + radius_now, now_y), radius_now, 90, 180, layer, t_width)

--- a/winding_generator.py
+++ b/winding_generator.py
@@ -270,10 +270,12 @@ def create_left_center(board: "pcbnew.BOARD", layer: int, center: "pcbnew.VECTOR
     ax, ay = center.x, center.y # center point (x,y) of the winding
     now_x = ax - (w_length // 2) - Clearance - (t_width // 2) # Starting point of the trace on the x-axis
     now_y = ay # Starting point of the trace on the y-axis
+    #TODO resolve first turn arc clearance issue
+    # The arc and the corners of the core touches or lacks correct clearance
     radius_now = radius + Clearance + (t_width // 2)  # adjusted radius of the first arc
 
     angle = 90
-    rad_inc1 = t_spacing + t_width # increment for last arc in each turn for n > 1
+    rad_inc1 = (t_spacing // 2) + (t_width // 2) # increment for last arc in each turn for n > 1
     rad_inc2 = rad_inc1
 
     limit = (w_height // 2) + Clearance + (t_width // 2)
@@ -331,11 +333,7 @@ def create_left_center(board: "pcbnew.BOARD", layer: int, center: "pcbnew.VECTOR
         add_track(board, v2(now_x, now_y), v2(now_x - f_length - rad_inc2, now_y), layer, t_width)
         now_x = now_x - f_length - rad_inc2
 
-        # TODO resolve assignment for Gap -> (t_spacing) and Guard -> (clearance)
-        # current usage seems to be interchanged
-        # TODO resolve conflicting implementation of t_spacing
-        # current spacing not correct
-        # update (rad_inc1 --> (t_spacing//2) + (t_width//2))
+
         radius_now = radius_now + rad_inc1 # Increment the radius of the arc to space out the next turn
 
         # Add arc top left


### PR DESCRIPTION
Hello Othman

I have made some changes in the create_left_center to ensure correct turn-turn spacing. 
The Turn-Core spacing is correct for the straight track but for the arc it is touching the corners of the core. 

I have also updated the README.md

Please have a look 